### PR TITLE
Update role_adapter.rb

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -46,7 +46,7 @@ module Rolify
       end
 
       def add(relation, role)
-        relation.role_ids |= [role.id]
+        relation.roles << role unless relation.roles.include?(role)
       end
 
       def remove(relation, role_name, resource = nil)


### PR DESCRIPTION
This method is much faster than `role_ids |= [role.id]`.

`.include?` does a fast exists check without having to load all the ids. The slowness is not in the insert, but in loading all the `role_ids`, which is not needed here.